### PR TITLE
Updated to QuizTrain 2.1.0

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,1 +1,1 @@
-github "venmo/QuizTrain" ~> 2.0.0
+github "venmo/QuizTrain" ~> 2.1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "venmo/QuizTrain" "2.0.0"
+github "venmo/QuizTrain" "2.1.0"

--- a/Example/Info.plist
+++ b/Example/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>2.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/ExampleTests/Info.plist
+++ b/ExampleTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>2.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSPrincipalClass</key>

--- a/ExampleUITests/Info.plist
+++ b/ExampleUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>2.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
- Updated to use [QuizTrain 2.1.0](https://github.com/venmo/QuizTrain/releases/tag/2.1.0).
    - *2.1.0 added Cocoapods support. There were no code changes made to QuizTrain itself.*
- Updated QuizTrainExample's version to 2.1.0.